### PR TITLE
Refresh DRE wizard styling and add time picker

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,54 +4,250 @@
   <meta charset="utf-8"/>
   <title>DRE Evaluation Wizard</title>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     :root{
-      --bg:#f5f7fb;--card:#fff;--line:#d8deeb;--muted:#6b7280;--ink:#102247;--accent:#0b5ed7;
-      --radius:10px;
+      --bg:#eef2ff;
+      --bg-secondary:#dfe7ff;
+      --surface:#ffffff;
+      --surface-alt:#f7f9ff;
+      --border:rgba(24,47,89,0.12);
+      --shadow:0 22px 50px rgba(15,23,42,0.16);
+      --ink:#0f172a;
+      --muted:#64748b;
+      --accent:#2563eb;
+      --accent-strong:#1d4ed8;
+      --accent-soft:rgba(37,99,235,0.14);
+      --radius-lg:20px;
+      --radius-md:14px;
+      --radius-sm:10px;
     }
     *{box-sizing:border-box}
-    body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial,sans-serif;background:var(--bg);color:var(--ink)}
-    header{background:linear-gradient(120deg,#021a38,#093b74);color:#fff;padding:16px 20px}
-    header h1{margin:0;font-size:20px;font-weight:600}
-    main{max-width:1200px;margin:18px auto;padding:0 16px 32px}
-    .panel{background:var(--card);border-radius:18px;box-shadow:0 18px 45px rgba(12,28,63,.14);padding:18px 20px}
-    .sec{margin-top:18px;border:1px solid var(--line);border-radius:16px;overflow:hidden;background:#fff}
-    .sec h2{margin:0;padding:14px 16px;font-size:15px;letter-spacing:.02em;text-transform:uppercase;background:linear-gradient(120deg,#eef3ff,#f5f7fb);border-bottom:1px solid var(--line);color:#0c2e63}
-    .sec .body{padding:16px}
-    .grid{display:grid;gap:14px}
-    .grid-3{grid-template-columns:repeat(auto-fit,minmax(230px,1fr))}
+    body{
+      margin:0;
+      font-family:'Inter',system-ui,Segoe UI,Arial,sans-serif;
+      background-image:radial-gradient(circle at top right,var(--bg-secondary),transparent 45%),radial-gradient(circle at bottom left,#f5f8ff,transparent 40%),linear-gradient(180deg,var(--bg) 0%,#f5f7ff 100%);
+      background-color:var(--bg);
+      color:var(--ink);
+      line-height:1.5;
+    }
+    header{
+      background:linear-gradient(125deg,#0f1e46 0%,#243b8f 55%,#3d63ff 100%);
+      color:#fff;
+      padding:22px clamp(20px,6vw,48px);
+      box-shadow:0 12px 35px rgba(17,35,90,0.35);
+      position:relative;
+      overflow:hidden;
+    }
+    header::after{
+      content:"";
+      position:absolute;
+      inset:auto -10% -60%;
+      height:160px;
+      background:radial-gradient(circle,#6d9bff 0%,transparent 70%);
+      opacity:.35;
+    }
+    header h1{
+      margin:0;
+      font-size:clamp(1.25rem,3vw,1.9rem);
+      font-weight:600;
+      letter-spacing:.015em;
+      position:relative;
+      z-index:1;
+    }
+    main{
+      max-width:1200px;
+      margin:-54px auto 48px;
+      padding:0 clamp(18px,4vw,40px) 48px;
+    }
+    .panel{
+      background:var(--surface);
+      border-radius:var(--radius-lg);
+      border:1px solid rgba(255,255,255,0.45);
+      box-shadow:var(--shadow);
+      padding:32px clamp(20px,4vw,36px);
+      backdrop-filter:blur(6px);
+    }
+    .panel form{display:flex;flex-direction:column;gap:20px}
+    .sec{
+      margin-top:20px;
+      border:1px solid var(--border);
+      border-radius:var(--radius-md);
+      overflow:hidden;
+      background:linear-gradient(180deg,var(--surface) 0%,var(--surface-alt) 100%);
+      box-shadow:0 10px 30px rgba(15,23,42,0.06);
+    }
+    .sec h2{
+      margin:0;
+      padding:16px clamp(14px,3vw,22px);
+      font-size:.95rem;
+      letter-spacing:.08em;
+      text-transform:uppercase;
+      background:linear-gradient(135deg,rgba(37,99,235,0.12),rgba(37,99,235,0.03));
+      border-bottom:1px solid var(--border);
+      color:#1d3363;
+      font-weight:600;
+    }
+    .sec .body{padding:20px clamp(16px,3vw,26px)}
+    .grid{display:grid;gap:18px}
+    .grid-3{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
     .grid-2{grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
     .grid-1{grid-template-columns:minmax(0,1fr)}
-    .field label{display:flex;flex-direction:column;font-size:13px;color:var(--muted);gap:6px;font-weight:500}
-    input,select,textarea{width:100%;padding:10px 12px;border:1px solid var(--line);border-radius:10px;font-size:14px;font-family:inherit;background:#fff;color:var(--ink)}
-    textarea{min-height:90px;resize:vertical}
+    .field label{
+      display:flex;
+      flex-direction:column;
+      gap:8px;
+      font-size:.83rem;
+      color:var(--muted);
+      font-weight:500;
+      letter-spacing:.01em;
+    }
+    input,select,textarea{
+      width:100%;
+      padding:11px 14px;
+      border:1px solid rgba(24,47,89,0.15);
+      border-radius:var(--radius-sm);
+      font-size:.9rem;
+      font-family:inherit;
+      background:linear-gradient(180deg,#ffffff 0%,#f7f9ff 100%);
+      color:var(--ink);
+      transition:border-color .2s ease,box-shadow .2s ease,background .2s ease;
+    }
+    input:focus,select:focus,textarea:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:0 0 0 4px var(--accent-soft);
+      background:#fff;
+    }
+    textarea{min-height:110px;resize:vertical}
     .inline{display:flex;flex-wrap:wrap;gap:12px;align-items:center}
-    .chip{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;background:#f1f4fd;border:1px solid var(--line);font-size:13px;font-weight:500;color:var(--ink)}
-    .group{border:1px solid var(--line);border-radius:12px;padding:12px;margin-top:6px}
-    .group-title{font-size:13px;font-weight:600;text-transform:uppercase;color:#0c2e63;margin-bottom:8px}
-    .group .option-row{display:flex;flex-wrap:wrap;gap:12px}
-    .group label.option{display:flex;align-items:center;gap:6px;font-size:13px;color:var(--ink);font-weight:500}
-    table.matrix{width:100%;border-collapse:collapse;margin-top:10px;font-size:13px}
-    table.matrix th,table.matrix td{border:1px solid var(--line);padding:8px 10px;text-align:left;vertical-align:top}
-    table.matrix th{background:#f4f7ff;color:#0c2e63;font-weight:600}
+    .chip{
+      display:inline-flex;
+      align-items:center;
+      gap:8px;
+      padding:7px 12px;
+      border-radius:999px;
+      background:rgba(15,23,42,0.04);
+      border:1px solid var(--border);
+      font-size:.82rem;
+      font-weight:500;
+      color:#1f2a44;
+    }
+    .group{
+      border:1px solid var(--border);
+      border-radius:var(--radius-md);
+      padding:16px 18px;
+      margin-top:10px;
+      background:var(--surface);
+      box-shadow:0 6px 18px rgba(15,23,42,0.05);
+    }
+    .group-title{
+      font-size:.78rem;
+      font-weight:600;
+      text-transform:uppercase;
+      color:#1f3f78;
+      margin-bottom:10px;
+      letter-spacing:.08em;
+    }
+    .group .option-row{display:flex;flex-wrap:wrap;gap:14px}
+    .group label.option{
+      display:inline-flex;
+      align-items:center;
+      gap:8px;
+      font-size:.85rem;
+      color:var(--ink);
+      font-weight:500;
+    }
+    .group label.option input{accent-color:var(--accent)}
+    table.matrix{width:100%;border-collapse:collapse;margin-top:14px;font-size:.85rem;background:var(--surface)}
+    table.matrix th,table.matrix td{border:1px solid var(--border);padding:10px 12px;text-align:left;vertical-align:top}
+    table.matrix thead th{background:rgba(37,99,235,0.12);color:#1f3064;font-weight:600}
+    table.matrix tbody tr:nth-child(even){background:rgba(15,23,42,0.02)}
     .muted{color:var(--muted)}
-    .actions{display:flex;flex-wrap:wrap;gap:10px;margin:18px 0}
-    button{background:var(--accent);color:#fff;font-weight:600;border:none;border-radius:999px;padding:10px 16px;cursor:pointer;font-size:14px}
-    button.secondary{background:#eaf0ff;color:#0c2e63}
-    button:disabled{opacity:.6;cursor:not-allowed}
-    .actions label.file{display:inline-flex;align-items:center;gap:10px;background:#eaf0ff;color:#0c2e63;border-radius:999px;padding:10px 16px;cursor:pointer}
+    .actions{display:flex;flex-wrap:wrap;gap:12px;margin:26px 0 18px}
+    button{
+      background:linear-gradient(135deg,var(--accent) 0%,var(--accent-strong) 100%);
+      color:#fff;
+      font-weight:600;
+      border:none;
+      border-radius:999px;
+      padding:11px 20px;
+      cursor:pointer;
+      font-size:.92rem;
+      letter-spacing:.01em;
+      transition:transform .15s ease,box-shadow .15s ease;
+      box-shadow:0 12px 25px rgba(37,99,235,0.28);
+    }
+    button:hover:not(:disabled){transform:translateY(-1px);box-shadow:0 16px 30px rgba(37,99,235,0.32)}
+    button.secondary{
+      background:rgba(37,99,235,0.12);
+      color:#1e3a8a;
+      box-shadow:none;
+      border:1px solid rgba(37,99,235,0.18);
+    }
+    button.secondary:hover:not(:disabled){background:rgba(37,99,235,0.16)}
+    button:disabled{opacity:.6;cursor:not-allowed;transform:none;box-shadow:none}
+    .actions label.file{
+      display:inline-flex;
+      align-items:center;
+      gap:10px;
+      background:rgba(37,99,235,0.12);
+      color:#1e3a8a;
+      border-radius:999px;
+      padding:11px 20px;
+      cursor:pointer;
+      border:1px solid rgba(37,99,235,0.18);
+      font-weight:600;
+      font-size:.9rem;
+      transition:background .15s ease,border-color .15s ease;
+    }
+    .actions label.file:hover{background:rgba(37,99,235,0.16)}
     .actions input[type=file]{display:none}
-    #narrative{background:#fdfdff;border:1px dashed var(--line);border-radius:12px;padding:16px;min-height:120px;font-size:14px;line-height:1.5;color:#1b2b4b;white-space:pre-wrap}
-    .pill-row{display:flex;flex-wrap:wrap;gap:8px;margin-top:6px}
-    .pill-row label{display:inline-flex;align-items:center;gap:6px;background:#f4f6fd;border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:12px;color:#0c2e63}
-    .subheading{font-size:12px;text-transform:uppercase;font-weight:600;color:#0c2e63;margin:10px 0 4px}
-    .note{font-size:12px;color:#4b5563;margin-top:4px}
-    .tight{gap:8px}
+    #narrative{
+      background:linear-gradient(135deg,#ffffff 0%,#f5f7ff 100%);
+      border:1px dashed rgba(24,47,89,0.25);
+      border-radius:var(--radius-md);
+      padding:20px;
+      min-height:140px;
+      font-size:.92rem;
+      line-height:1.65;
+      color:#1b2b4b;
+      white-space:pre-wrap;
+      box-shadow:0 8px 24px rgba(15,23,42,0.08);
+    }
+    .pill-row{display:flex;flex-wrap:wrap;gap:10px;margin-top:10px}
+    .pill-row label{
+      display:inline-flex;
+      align-items:center;
+      gap:8px;
+      background:rgba(15,23,42,0.04);
+      border:1px solid var(--border);
+      padding:7px 12px;
+      border-radius:999px;
+      font-size:.78rem;
+      color:#1f2a44;
+    }
+    .pill-row label input{accent-color:var(--accent)}
+    .subheading{font-size:.78rem;text-transform:uppercase;font-weight:600;color:#1f3f78;margin:18px 0 6px;letter-spacing:.08em}
+    .note{font-size:.78rem;color:#4b5563;margin-top:6px}
+    .tight{gap:10px}
     .field.full{grid-column:1/-1}
     .table-scroll{overflow-x:auto}
     .table-scroll table{min-width:680px}
-    .mini-input{width:72px}
-    .checkbox-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:8px}
+    .mini-input{width:80px}
+    .checkbox-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}
+    code{font-family:"Fira Code",ui-monospace,Menlo,monospace;background:rgba(15,23,42,0.08);padding:2px 6px;border-radius:6px;font-size:.8rem}
+    .hidden{display:none !important}
+    @media (max-width:720px){
+      header{padding:20px 22px}
+      main{margin:-40px auto 40px}
+      .panel{padding:26px 18px}
+      .table-scroll table{min-width:600px}
+      .actions{flex-direction:column;align-items:stretch}
+      .actions > *{width:100%;justify-content:center;text-align:center}
+    }
   </style>
 </head>
 <body>
@@ -487,7 +683,7 @@
             ${renderInput({ name:"When_Drinking", label:"When drinking?" })}
             ${renderInput({ name:"Last_Drink", label:"Time of last drink" })}
             ${renderInput({ name:"Time_Now", label:"Time now (stated)" })}
-            ${renderInput({ name:"Time_Actual", label:"Actual current time" })}
+            ${renderInput({ name:"Time_Actual", label:"Actual current time", type:"time" })}
             ${renderInput({ name:"Last_Slept", label:"When last slept" })}
             ${renderInput({ name:"Sleep_Amount", label:"How long slept" })}
           </div>`


### PR DESCRIPTION
## Summary
- modernize the public UI with updated typography, gradients, and refined card/table styling
- add utility styling improvements, including better focus states, pill chips, and narrative preview presentation
- convert the "Actual current time" interview field into a native time input for consistent entry

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68cde7aef1e083329db188fc7d8bb985